### PR TITLE
fix cookie authentication

### DIFF
--- a/down.py
+++ b/down.py
@@ -48,7 +48,7 @@ def main(url, token, cookie, output):
 
     if cookie:
         cookies = {
-            'session': token
+            'session': cookie
         }
         s.cookies.update(cookies)
 


### PR DESCRIPTION
Seems that the API token was being passed as the cookie, I guess a typo.

Cookie downloads didn't work for me, now they work